### PR TITLE
Qiitaの記事検索機能を実装

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,7 +38,7 @@ android {
         applicationId = "com.example.flutter_qiita_tutorial"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdk = flutter.minSdkVersion
+        minSdkVersion 19
         targetSdk = flutter.targetSdkVersion
         versionCode = flutterVersionCode.toInteger()
         versionName = flutterVersionName

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '12.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_qiita_tutorial/screens/search_screen.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
-void main() {
+Future<void> main() async {
+  await dotenv.load(fileName: '.env');
   runApp(const MainApp());
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,16 +13,19 @@ class MainApp extends StatelessWidget {
     return MaterialApp(
       title: 'Qiita Search', // titleを追加
       theme: ThemeData( // themeを追加
-      primarySwatch: Colors.green,
-      fontFamily: 'Hiragino Sans',
-      appBarTheme: const AppBarTheme(
-      backgroundColor: Color(0xFF55C500),
-    ),
-    textTheme: Theme.of(context).textTheme.apply(
-    bodyColor: Colors.white,
-    ),
-    ),
-    home: const SearchScreen(), // SearchScreenを設定
+        primarySwatch: Colors.green,
+        fontFamily: 'Hiragino Sans',
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Color(0xFF55C500),
+        ),
+        textTheme: Theme
+            .of(context)
+            .textTheme
+            .apply(
+          bodyColor: Colors.white,
+        ),
+      ),
+      home: const SearchScreen(), // SearchScreenを設定
     );
   }
 }

--- a/lib/models/article.dart
+++ b/lib/models/article.dart
@@ -1,4 +1,4 @@
-import 'package:qiita_search/models/user.dart';
+import 'package:flutter_qiita_tutorial/models/user.dart';
 
 class Article {
   // コンストラクタ

--- a/lib/models/article.dart
+++ b/lib/models/article.dart
@@ -1,0 +1,19 @@
+class Article {
+  // コンストラクタ
+  Article({
+    required this.title,
+    required this.user,
+    this.likesCount = 0, // デフォルト値を0で設定
+    this.tags = const [], // デフォルト値を空配列で設定
+    required this.createdAt,
+    required this.url,
+  });
+
+  // プロパティ
+  final String title;
+  final User user;
+  final int likesCount;
+  final List<String> tags;
+  final DateTime createdAt;
+  final String url;
+}

--- a/lib/models/article.dart
+++ b/lib/models/article.dart
@@ -1,3 +1,5 @@
+import 'package:qiita_search/models/user.dart';
+
 class Article {
   // コンストラクタ
   Article({
@@ -16,4 +18,19 @@ class Article {
   final List<String> tags;
   final DateTime createdAt;
   final String url;
+
+  // JSONからArticleを生成するファクトリコンストラクタ
+  factory Article.fromJson(dynamic json) {
+    return Article(
+      title: json['title'] as String,
+      user: User.fromJson(json['user']),
+      // User.fromJson()を使ってUserを生成
+      url: json['url'] as String,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      // DateTime.parse()を使って文字列をDateTimeに変換
+      likesCount: json['likes_count'] as int,
+      tags: List<String>.from(json['tags'].map((
+          tag) => tag['name'])), // List<String>.from()を使ってList<String>に変換
+    );
+  }
 }

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,0 +1,11 @@
+class User {
+  // コンストラクタ
+  User({
+    required this.id,
+    required this.profileImageUrl,
+  });
+
+  // プロパティ
+  final String id;
+  final String profileImageUrl;
+}

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -8,4 +8,12 @@ class User {
   // プロパティ
   final String id;
   final String profileImageUrl;
+
+  // JSONからUserを生成するファクトリコンストラクタ
+  factory User.fromJson(dynamic json) {
+    return User(
+      id: json['id'] as String,
+      profileImageUrl: json['profile_image_url'] as String,
+    );
+  }
 }

--- a/lib/screens/article_screen.dart
+++ b/lib/screens/article_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class ArticleScreen extends StatefulWidget {
+  const ArticleScreen({
+    super.key,
+  });
+
+  @override
+  State<ArticleScreen> createState() => _ArticleScreenState();
+}
+
+class _ArticleScreenState extends State<ArticleScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Article Page'),
+      ),
+      body: null,
+    );
+  }
+}

--- a/lib/screens/article_screen.dart
+++ b/lib/screens/article_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_qiita_tutorial/models/article.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 
 class ArticleScreen extends StatefulWidget {
   const ArticleScreen({
@@ -13,13 +14,18 @@ class ArticleScreen extends StatefulWidget {
 }
 
 class _ArticleScreenState extends State<ArticleScreen> {
+  late WebViewController controller = WebViewController()
+    ..loadRequest(
+        Uri.parse(widget.article.url),
+    );
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Article Page'),
       ),
-      body: null,
+      body: WebViewWidget(controller: controller),
     );
   }
 }

--- a/lib/screens/article_screen.dart
+++ b/lib/screens/article_screen.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_qiita_tutorial/models/article.dart';
 
 class ArticleScreen extends StatefulWidget {
   const ArticleScreen({
     super.key,
+    required this.article,
   });
+  final Article article;
 
   @override
   State<ArticleScreen> createState() => _ArticleScreenState();

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -32,6 +32,9 @@ class _SearchScreenState extends State<SearchScreen> {
     });
 
     // 2. Qiita APIにリクエストを送る
+    // アクセストークンを取得
+    final String token = dotenv.env['QIITA_ACCESS_TOKEN'] ?? '';
+
     // 3. 戻り値をArticleクラスの配列に変換
     // 4. 変換したArticleクラスの配列を返す(returnする)
   }

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -12,6 +12,7 @@ class SearchScreen extends StatefulWidget {
 }
 
 class _SearchScreenState extends State<SearchScreen> {
+  List<Article> articles = []; // 検索結果を格納する変数
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -36,8 +37,9 @@ class _SearchScreenState extends State<SearchScreen> {
                 // ← InputDecorationを渡す
                 hintText: '検索ワードを入力してください',
               ),
-              onSubmitted: (String value) {
-                print("検索中: $value");
+              onSubmitted: (String value) async {
+                final results = await searchQiita(value); //検索処理を実行す
+                setState(()=> articles = results); //検索結果を代入
               },
             ),
           ),

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'package:http/http.dart' as http; // httpという変数を通して、httpパッケージにアクセス
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_qiita_tutorial/models/article.dart';
+import '../models/article.dart';
+import '../models/user.dart';
 
 class SearchScreen extends StatefulWidget {
   const SearchScreen({super.key});
@@ -40,12 +42,24 @@ class _SearchScreenState extends State<SearchScreen> {
               ),
               onSubmitted: (String value) async {
                 final results = await searchQiita(value); //検索処理を実行す
-                setState(()=> articles = results); //検索結果を代入
+                setState(() => articles = results); //検索結果を代入
               },
             ),
           ),
-          const ArticleContainer(),//検索結果一覧
-        ],
+          ArticleContainer(
+            article: Article(
+              title: 'テスト',
+              user: User(
+                id: 'qii-taro',
+                profileImageUrl:
+                    'https://firebasestorage.googleapis.com/v0/b/gs-expansion-test.appspot.com/o/unknown_person.png?alt=media',
+              ),
+              createdAt: DateTime.now(),
+              tags: ['Flutter', 'dart'],
+              url: 'https://example.com',
+            ),
+          ),
+        ], //検索結果一覧
       ),
     );
   }

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -47,6 +47,8 @@ class _SearchScreenState extends State<SearchScreen> {
     } else {
       return [];
     }
-
+// レスポンスをモデルクラスへ変換
+    final List<dynamic> body = jsonDecode(res.body);
+    return body.map((dynamic json) => Article.fromJson(json)).toList();
   }
 }

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -36,6 +36,11 @@ class _SearchScreenState extends State<SearchScreen> {
     final String token = dotenv.env['QIITA_ACCESS_TOKEN'] ?? '';
 
     // 3. 戻り値をArticleクラスの配列に変換
+    // アクセストークンを含めてリクエストを送信
+    final http.Response res = await http.get(uri, headers: {
+      'Authorization': 'Bearer $token',
+    });
+
     // 4. 変換したArticleクラスの配列を返す(returnする)
   }
 }

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -42,5 +42,11 @@ class _SearchScreenState extends State<SearchScreen> {
     });
 
     // 4. 変換したArticleクラスの配列を返す(returnする)
+    if (res.statusCode == 200) {
+      // モデルクラスへ変換
+    } else {
+      return [];
+    }
+
   }
 }

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'dart:convert';
+import 'package:http/http.dart' as http; // httpという変数を通して、httpパッケージにアクセス
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_qiita_tutorial/models/article.dart';
 
 class SearchScreen extends StatefulWidget {
   const SearchScreen({super.key});

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -18,7 +18,27 @@ class _SearchScreenState extends State<SearchScreen> {
       appBar: AppBar(
         title: const Text('Qiita Search'),
       ),
-      body: Container(),
+      body: Column(
+        children: [
+          //検索ボックス
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              vertical: 12,
+              horizontal: 36,
+            ),
+            child: TextField(
+              style: TextStyle( //Textstyleを渡す
+                 fontSize: 18,
+              color: Colors.black,
+              ),
+              decoration: InputDecoration( // ← InputDecorationを渡す
+                hintText: '検索ワードを入力してください',
+              ),
+            ),
+          ),
+          //検索結果一覧
+        ],
+      ),
     );
   }
 

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -21,4 +21,11 @@ class _SearchScreenState extends State<SearchScreen> {
       body: Container(),
     );
   }
+
+  Future<List<Article>> searchQiita(String keyword) async {
+    // 1. http通信に必要なデータを準備をする
+    // 2. Qiita APIにリクエストを送る
+    // 3. 戻り値をArticleクラスの配列に変換
+    // 4. 変換したArticleクラスの配列を返す(returnする)
+  }
 }

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -24,6 +24,13 @@ class _SearchScreenState extends State<SearchScreen> {
 
   Future<List<Article>> searchQiita(String keyword) async {
     // 1. http通信に必要なデータを準備をする
+    // Uri.https([baseUrl], [Urlパス], Map<String,dynamic>[クエリパラメータ])
+
+    final uri = Uri.https('qiita.com', '/api/v2/items', {
+      'query': 'title:$keyword',
+      'per_page': '10',
+    });
+
     // 2. Qiita APIにリクエストを送る
     // 3. 戻り値をArticleクラスの配列に変換
     // 4. 変換したArticleクラスの配列を返す(returnする)

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -46,17 +46,11 @@ class _SearchScreenState extends State<SearchScreen> {
               },
             ),
           ),
-          ArticleContainer(
-            article: Article(
-              title: 'テスト',
-              user: User(
-                id: 'qii-taro',
-                profileImageUrl:
-                    'https://firebasestorage.googleapis.com/v0/b/gs-expansion-test.appspot.com/o/unknown_person.png?alt=media',
-              ),
-              createdAt: DateTime.now(),
-              tags: ['Flutter', 'dart'],
-              url: 'https://example.com',
+          Expanded(
+            child: ListView(
+              children: articles
+                  .map((article2) => ArticleContainer(article: article2))
+                  .toList(),
             ),
           ),
         ], //検索結果一覧

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -27,13 +27,18 @@ class _SearchScreenState extends State<SearchScreen> {
               horizontal: 36,
             ),
             child: TextField(
-              style: TextStyle( //Textstyleを渡す
-                 fontSize: 18,
-              color: Colors.black,
+              style: TextStyle(
+                //Textstyleを渡す
+                fontSize: 18,
+                color: Colors.black,
               ),
-              decoration: InputDecoration( // ← InputDecorationを渡す
+              decoration: InputDecoration(
+                // ← InputDecorationを渡す
                 hintText: '検索ワードを入力してください',
               ),
+              onSubmitted: (String value) {
+                print("検索中: $value");
+              },
             ),
           ),
           //検索結果一覧

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_qiita_tutorial/widgets/article_container.dart';
 import 'dart:convert';
 import 'package:http/http.dart' as http; // httpという変数を通して、httpパッケージにアクセス
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -43,7 +44,7 @@ class _SearchScreenState extends State<SearchScreen> {
               },
             ),
           ),
-          //検索結果一覧
+          const ArticleContainer(),//検索結果一覧
         ],
       ),
     );

--- a/lib/widgets/article_container.dart
+++ b/lib/widgets/article_container.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class ArticleContainer extends StatelessWidget {
+  const ArticleContainer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric( // ← 内側の余白を指定
+        horizontal: 20,
+        vertical: 16,
+      ),
+      decoration: const BoxDecoration(
+        color: Color(0xFF55C500), // ← 背景色を指定
+        borderRadius: BorderRadius.all(
+          Radius.circular(32),// ← 角丸を設定
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/article_container.dart
+++ b/lib/widgets/article_container.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import '../models/article.dart';
+import 'package:flutter_qiita_tutorial/models/article.dart';
+import 'package:intl/intl.dart';
+
 
 class ArticleContainer extends StatelessWidget {
   const ArticleContainer({
@@ -18,18 +20,89 @@ class ArticleContainer extends StatelessWidget {
       ),
       child: Container(
         padding: const EdgeInsets.symmetric(
-          // ← 内側の余白を指定
+          // 内側の余白を指定
           horizontal: 20,
           vertical: 16,
         ),
         decoration: const BoxDecoration(
-          color: Color(0xFF55C500), // ← 背景色を指定
+          color: Color(0xFF55C500), // 背景色を指定
           borderRadius: BorderRadius.all(
-            Radius.circular(32), // ← 角丸を設定
+            Radius.circular(32), // 角丸を設定
           ),
         ),
-        child: const Column(
-          children: [],
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 投稿日
+            Text(
+              DateFormat('yyyy/MM/dd').format(article.createdAt),
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 12,
+              ),
+            ),
+            // タイトル
+            Text(
+              article.title,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+            // タグ
+            Text(
+              '#${article.tags.join(' #')}',
+              style: const TextStyle(
+                fontSize: 12,
+                color: Colors.white,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                // ハートアイコンといいね数
+                Column(
+                  children: [
+                    const Icon(
+                      Icons.favorite,
+                      color: Colors.white,
+                    ),
+                    Text(
+                      article.likesCount.toString(),
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ],
+                ),
+                // 投稿者のアイコンと投稿者名
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    CircleAvatar(
+                      radius: 26,
+                      backgroundImage:
+                          NetworkImage(article.user.profileImageUrl),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      article.user.id,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/lib/widgets/article_container.dart
+++ b/lib/widgets/article_container.dart
@@ -5,15 +5,21 @@ class ArticleContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric( // ← 内側の余白を指定
-        horizontal: 20,
-        vertical: 16,
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        vertical: 12,
+        horizontal: 16,
       ),
-      decoration: const BoxDecoration(
-        color: Color(0xFF55C500), // ← 背景色を指定
-        borderRadius: BorderRadius.all(
-          Radius.circular(32),// ← 角丸を設定
+      child: Container(
+        padding: const EdgeInsets.symmetric( // ← 内側の余白を指定
+          horizontal: 20,
+          vertical: 16,
+        ),
+        decoration: const BoxDecoration(
+          color: Color(0xFF55C500), // ← 背景色を指定
+          borderRadius: BorderRadius.all(
+            Radius.circular(32),// ← 角丸を設定
+          ),
         ),
       ),
     );

--- a/lib/widgets/article_container.dart
+++ b/lib/widgets/article_container.dart
@@ -28,6 +28,9 @@ class ArticleContainer extends StatelessWidget {
             Radius.circular(32), // ← 角丸を設定
           ),
         ),
+        child: const Column(
+          children: [],
+        ),
       ),
     );
   }

--- a/lib/widgets/article_container.dart
+++ b/lib/widgets/article_container.dart
@@ -1,7 +1,13 @@
 import 'package:flutter/material.dart';
+import '../models/article.dart';
 
 class ArticleContainer extends StatelessWidget {
-  const ArticleContainer({super.key});
+  const ArticleContainer({
+    super.key,
+    required this.article,
+  });
+
+  final Article article;
 
   @override
   Widget build(BuildContext context) {
@@ -11,14 +17,15 @@ class ArticleContainer extends StatelessWidget {
         horizontal: 16,
       ),
       child: Container(
-        padding: const EdgeInsets.symmetric( // ← 内側の余白を指定
+        padding: const EdgeInsets.symmetric(
+          // ← 内側の余白を指定
           horizontal: 20,
           vertical: 16,
         ),
         decoration: const BoxDecoration(
           color: Color(0xFF55C500), // ← 背景色を指定
           borderRadius: BorderRadius.all(
-            Radius.circular(32),// ← 角丸を設定
+            Radius.circular(32), // ← 角丸を設定
           ),
         ),
       ),

--- a/lib/widgets/article_container.dart
+++ b/lib/widgets/article_container.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_qiita_tutorial/models/article.dart';
 import 'package:intl/intl.dart';
 
+import '../screens/article_screen.dart';
+
 
 class ArticleContainer extends StatelessWidget {
   const ArticleContainer({
@@ -18,91 +20,102 @@ class ArticleContainer extends StatelessWidget {
         vertical: 12,
         horizontal: 16,
       ),
-      child: Container(
-        padding: const EdgeInsets.symmetric(
-          // 内側の余白を指定
-          horizontal: 20,
-          vertical: 16,
-        ),
-        decoration: const BoxDecoration(
-          color: Color(0xFF55C500), // 背景色を指定
-          borderRadius: BorderRadius.all(
-            Radius.circular(32), // 角丸を設定
+
+      child: GestureDetector(
+        onTap: () {
+          Navigator.of(context).push(
+              MaterialPageRoute(
+              builder: ((context) => ArticleScreen(article: article)),
+              ),
+          );
+          print("タップ");
+        },
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+            // 内側の余白を指定
+            horizontal: 20,
+            vertical: 16,
           ),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // 投稿日
-            Text(
-              DateFormat('yyyy/MM/dd').format(article.createdAt),
-              style: const TextStyle(
-                color: Colors.white,
-                fontSize: 12,
-              ),
+          decoration: const BoxDecoration(
+            color: Color(0xFF55C500), // 背景色を指定
+            borderRadius: BorderRadius.all(
+              Radius.circular(32), // 角丸を設定
             ),
-            // タイトル
-            Text(
-              article.title,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
-                color: Colors.white,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // 投稿日
+              Text(
+                DateFormat('yyyy/MM/dd').format(article.createdAt),
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 12,
+                ),
               ),
-            ),
-            // タグ
-            Text(
-              '#${article.tags.join(' #')}',
-              style: const TextStyle(
-                fontSize: 12,
-                color: Colors.white,
-                fontStyle: FontStyle.italic,
+              // タイトル
+              Text(
+                article.title,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white,
+                ),
               ),
-            ),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                // ハートアイコンといいね数
-                Column(
-                  children: [
-                    const Icon(
-                      Icons.favorite,
-                      color: Colors.white,
-                    ),
-                    Text(
-                      article.likesCount.toString(),
-                      style: const TextStyle(
-                        fontSize: 12,
+              // タグ
+              Text(
+                '#${article.tags.join(' #')}',
+                style: const TextStyle(
+                  fontSize: 12,
+                  color: Colors.white,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  // ハートアイコンといいね数
+                  Column(
+                    children: [
+                      const Icon(
+                        Icons.favorite,
                         color: Colors.white,
                       ),
-                    ),
-                  ],
-                ),
-                // 投稿者のアイコンと投稿者名
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    CircleAvatar(
-                      radius: 26,
-                      backgroundImage:
-                          NetworkImage(article.user.profileImageUrl),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      article.user.id,
-                      style: const TextStyle(
-                        fontSize: 12,
-                        color: Colors.white,
+                      Text(
+                        article.likesCount.toString(),
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: Colors.white,
+                        ),
                       ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ],
+                    ],
+                  ),
+                  // 投稿者のアイコンと投稿者名
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      CircleAvatar(
+                        radius: 26,
+                        backgroundImage:
+                            NetworkImage(article.user.profileImageUrl),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        article.user.id,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
   flutter_dotenv: ^5.1.0
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
+  flutter_dotenv: ^5.1.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,9 +60,8 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
+  assets:
+    - .env
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   cupertino_icons: ^1.0.6
   flutter_dotenv: ^5.1.0
   http: ^1.2.1
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   flutter_dotenv: ^5.1.0
   http: ^1.2.1
   intl: ^0.19.0
+  webview_flutter: ^4.8.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要

- 記事検索機能を実装
- 以下のパッケージ追加
  - WebViewController
  - flutter_dotenv

## 詳細

- WebViewControllerでweb上にある記事のリストをアプリ内に呼び込み表示。
- Qiitaの記事をAPI通信で呼び出す際に必要なアクセストークンを随時稼動させる為、dotenvを使用する。
- WebViewController
  - webサイトにアップされている記事をアプリ内で呼び出し表示させるため
  - https://pub.dev/packages/webview_flutter
- flutter_dotenv
  - アクセストークンを秘匿化するため
  - アクセストークンはgitignoreしている
  - https://pub.dev/packages/flutter_dotenv

## 確認方法
AndroidStudioでの確認手順...
- 手順1　AndroidStudioのスタートボタンを押す
- 手順2　エミュレータはPixel 8 API VanillaIceCreamを使用
- 手順3　例：検索ワードを入力してくださいの箇所に「WebView」と入力し、enterを
- 手順4　
...

## 参考文献

- https://zenn.dev/heyhey1028/books/flutter-basics/viewer/hands_on_6